### PR TITLE
Fix make install so it runs on fc28

### DIFF
--- a/makefile
+++ b/makefile
@@ -29,14 +29,16 @@ script: ./sort-and-run.sh.template directory
 # Add a uinput user to the system
 group:
 	$(GROUPADD_PATH) -f uinput
-	adduser --system --quiet --no-create-home --shell /bin/false --ingroup uinput uinput
+	id -u uinput > /dev/null 2>&1 || useradd --system --no-create-home --shell /bin/false -g uinput uinput > /dev/null
 
 # Ensure the existence of a directory within the prefix location
 directory:
 	mkdir $(INSTALLPATH) || true # ensure doesn't crash if already exists
 
-# Copy the binary to its new home
+# Copy the binary to its new home. Unlink any existing file first in case the
+# service is already running.
 binary: directory kfreestyle2d
+	rm -f $(INSTALLPATH)/kfreestyle2d
 	cp kfreestyle2d $(INSTALLPATH)/kfreestyle2d
 	chgrp $(GROUP) $(INSTALLPATH)/kfreestyle2d
 


### PR DESCRIPTION
I just found this repo today, by way of your blog writeup on getting the multimedia keys working on the freestyle 2 in linux. Thanks for doing the research and writing this driver! Now I can switch tracks and adjust my music volume without reaching for my mouse.

I got `make install` working on fedora core 28 by switching  `adduser` to `useradd` and making minor changes to the args. I also added a step to unlink the existing binary install target before copying the new one - without this step, subsequent runs of `make install` fail with a `Text file busy` error. I also tested the changes in a VM running Ubuntu 18.04, where `make install` succeeded (I did not test that the driver functions there, however).

Fixes #6 