### PR TITLE
Start service after user sessions

### DIFF
--- a/99-kfreestyle2d.rules.template
+++ b/99-kfreestyle2d.rules.template
@@ -2,4 +2,4 @@
 KERNEL=="uinput", GROUP="<<<GROUP>>>", MODE:="0660"
 
 # Make kinesis raw input keys readable
-KERNEL=="hidraw*", ATTRS{idVendor}=="058f", ATTRS{idProduct}=="9410", MODE:="0660", GROUP="<<<GROUP>>>", SYMLINK="kinesis%n", RUN+="/bin/systemctl --no-block start kfreestyle2d.service"
+KERNEL=="hidraw*", ATTRS{idVendor}=="058f", ATTRS{idProduct}=="9410", MODE:="0660", GROUP="<<<GROUP>>>", SYMLINK="kinesis%n", TAG+="systemd", ENV{SYSTEMD_WANTS}="kfreestyle2d.service"

--- a/kfreestyle2d.service.template
+++ b/kfreestyle2d.service.template
@@ -1,5 +1,6 @@
 [Unit]
 Description=Userspace driver for Kinesis Freestyle 2 Keyboard
+After=dev-systemd-user-sessions.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
Follow up on #10.

This works on startup. It's kind of a hack to wait for something unrelated like user session service. But if you don't wait it's random whether the uinput driver gets the first or second device.